### PR TITLE
iPad Keyboard Shortcuts support

### DIFF
--- a/Classes/ChattyViewController.h
+++ b/Classes/ChattyViewController.h
@@ -31,6 +31,7 @@
 @property (nonatomic, strong) NSMutableArray *threads;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, assign) NSUInteger storyId;
+@property (nonatomic, assign) NSIndexPath *selectedRowPath;
 
 + (ChattyViewController*)chattyControllerWithLatest;
 + (ChattyViewController*)chattyControllerWithStoryId:(NSUInteger)aStoryId;

--- a/Classes/ThreadViewController.m
+++ b/Classes/ThreadViewController.m
@@ -739,6 +739,51 @@
     return minTimeLevelPostIndex;
 }
 
+- (BOOL)canBecomeFirstResponder {
+    return YES;
+}
+
+- (NSArray<UIKeyCommand *>*)keyCommands {
+    return @[
+             [UIKeyCommand keyCommandWithInput:@"a" modifierFlags:0 action:@selector(prevTab:) discoverabilityTitle:@"Previous Subthread"],
+             [UIKeyCommand keyCommandWithInput:@"z" modifierFlags:0 action:@selector(nextTab:) discoverabilityTitle:@"Next Subthread"],
+             [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow modifierFlags:0 action:@selector(prevTabThreader:) discoverabilityTitle:@"Previous Thread"],
+             [UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow modifierFlags:0 action:@selector(nextTabThreader:) discoverabilityTitle:@"Next Thread"],
+             [UIKeyCommand keyCommandWithInput:@"r" modifierFlags:UIKeyModifierCommand action:@selector(refreshTableview:) discoverabilityTitle:@"Refresh Threads"],
+             [UIKeyCommand keyCommandWithInput:@"p" modifierFlags:UIKeyModifierCommand action:@selector(threadPinnedKey:) discoverabilityTitle:@"Toggle Thread Pinned"],
+             [UIKeyCommand keyCommandWithInput:@"r" modifierFlags:0 action:@selector(replyToPost:) discoverabilityTitle:@"Reply to Post"]
+             ];
+}
+
+- (void)threadPinnedKey:(UIKeyCommand *)sender {
+    [self togglePinThread];
+}
+
+- (void)refreshTableview:(UIKeyCommand *)sender {
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RefreshView" object:self];
+}
+
+- (void)prevTabThreader:(UIKeyCommand *)sender {
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"PrevThread" object:self];
+}
+
+- (void)nextTabThreader:(UIKeyCommand *)sender {
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"NextThread" object:self];
+}
+
+- (void)prevTab:(UIKeyCommand *)sender {
+    [self previous];
+}
+
+- (void)nextTab:(UIKeyCommand *)sender {
+    [self next];
+}
+
+- (void)replyToPost:(UIKeyCommand *)sender {
+    [self tappedReplyButton];
+}
+
+
 - (IBAction)previous {
     NSIndexPath *oldIndexPath = selectedIndexPath;
         


### PR DESCRIPTION
_Apologies for first submitting this to Squeegy, I am submitting the PR here instead_

I have been using this code for months without issues. I finally decided it was time to get it up for a pull request. I think this feature will be helpful, especially for iPad Pro users who are used to using a keyboard case.

This supports the standard method of showing a hint page by holding down "CMD" for a few seconds like other iOS apps.

Here are the shortcuts listed out:

| Name | Binding |
| ------------- | ------------- |
| Previous Thread | Up Arrow  |
| Next Thread  | Down Arrow  |
| Refresh Threads  | CMD+R  |
| Previous Subthread | A |
| Next Subthread | Z |
| Reply to Post | R |
| Pin Thread Toggle | CMD+P |
